### PR TITLE
Fix PGS implementation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "libpgs",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "libpgs",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "license": "MIT",
       "devDependencies": {
         "@tsconfig/recommended": "^1.0.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "libpgs",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "author": "David Schulte",
   "license": "MIT",
   "description": "Renderer for graphical subtitles (PGS) in the browser. ",


### PR DESCRIPTION
The old implementation ignored segments from previous display sets. However, the PGS specification does only clear previous segments if the composition state is set.

The new implementation now collects all active segments from previous segments.