### PR TITLE
Performance improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This library renders the graphical subtitles format PGS _(.sub / .sup)_ in the b
 
 ## Work in progress
 
-This project is still in progress. It should be able to play 99% of Blue ray subtitles _(Yes, I made that number up)_. 
+This project is still in progress. It should be able to play 99% of Blu-ray subtitles _(Yes, I made that number up)_. 
 But some rare used PGS features - like cropping - aren't implemented yet.
 
 If you know a movie or show that is using the cropping feature, please let me know!

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "libpgs",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "libpgs",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "license": "MIT",
       "devDependencies": {
         "@rollup/plugin-terser": "^0.4.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "libpgs",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "author": "David Schulte",
   "license": "MIT",
   "description": "Renderer for graphical subtitles (PGS) in the browser. ",

--- a/src/pgs/paletteDefinitionSegment.ts
+++ b/src/pgs/paletteDefinitionSegment.ts
@@ -2,22 +2,10 @@ import {Segment} from "./segment";
 import {SegmentType} from "./segmentType";
 import {BigEndianBinaryReader} from "../utils/bigEndianBinaryReader";
 
-export class PaletteEntry {
-    public y: number = 0;
-    public cr: number = 0;
-    public cb: number = 0;
-
-    public r: number = 0;
-    public g: number = 0;
-    public b: number = 0;
-
-    public a: number = 0;
-}
-
 export class PaletteDefinitionSegment implements Segment {
     public id: number = 0;
     public versionNumber: number = 0;
-    public entries: { [key: number]: PaletteEntry } = {};
+    public rgba: number[] = [];
 
     public get segmentType(): number {
         return SegmentType.paletteDefinition;
@@ -28,30 +16,38 @@ export class PaletteDefinitionSegment implements Segment {
         this.versionNumber = reader.readUInt8();
 
         const count = (length - 2) / 5;
-        this.entries = {};
+
+        // Creates a buffer to store the mapping as the 4 byte color data.
+        const data32 = new Uint32Array(1);
+        const data8 = new Uint8Array(data32.buffer);
+
+        this.rgba = [];
         for (let i = 0; i < count; i++) {
             const id = reader.readUInt8();
-            const entry = new PaletteEntry();
 
             // Load the YCrCbA value
-            entry.y = reader.readUInt8();
-            entry.cr = reader.readUInt8();
-            entry.cb = reader.readUInt8();
-            entry.a = reader.readUInt8();
+            const y = reader.readUInt8();
+            const cr = reader.readUInt8() - 128;
+            const cb = reader.readUInt8() - 128;
+            const a = reader.readUInt8();
 
-            // Also store the RGBA value
-            const y = entry.y;
-            const cb = entry.cb - 128;
-            const cr = entry.cr - 128;
-            entry.r = PaletteDefinitionSegment.clamp(Math.round(y + 1.40200 * cr), 0, 255);
-            entry.g = PaletteDefinitionSegment.clamp(Math.round(y - 0.34414 * cb - 0.71414 * cr), 0, 255);
-            entry.b = PaletteDefinitionSegment.clamp(Math.round(y + 1.77200 * cb), 0, 255);
+            // Convert to rgba
+            const r = PaletteDefinitionSegment.clamp(Math.round(y + 1.40200 * cr), 0, 255);
+            const g = PaletteDefinitionSegment.clamp(Math.round(y - 0.34414 * cb - 0.71414 * cr), 0, 255);
+            const b = PaletteDefinitionSegment.clamp(Math.round(y + 1.77200 * cb), 0, 255);
 
-            this.entries[id] = entry;
+            // Convert to 32bit number for faster copy in the image decode.
+            // We cannot use the bit-shifting here. The buffers will keep the systems endianness. The same endianness
+            // must be used to write the rgba values to the pixel buffer to even out.
+            data8[0] = r;
+            data8[1] = g;
+            data8[2] = b;
+            data8[3] = a;
+            this.rgba[id] = data32[0];
         }
     }
 
     private static clamp(value: number, min: number, max: number): number {
-        return Math.max(min, Math.min(value, max));
+        return value < min ? min : value > max ? max : value;
     }
 }

--- a/src/pgsRenderer.ts
+++ b/src/pgsRenderer.ts
@@ -1,4 +1,5 @@
 import {PgsRendererOptions} from "./pgsRendererOptions";
+import {PgsRendererHelper} from "./pgsRendererHelper";
 
 /**
  * Renders PGS subtitle on-top of a video element using a canvas element. This also handles timestamp updates if a
@@ -132,21 +133,7 @@ export class PgsRenderer {
      * @param time The timestamp in seconds.
      */
     public renderAtTimestamp(time: number): void {
-        time = time * 1000 * 90; // Convert to PGS time
-
-        // All position before and after the available timestamps are invalid (-1).
-        let index = -1;
-        if (this.updateTimestamps.length > 0 && time < this.updateTimestamps[this.updateTimestamps.length - 1]) {
-
-            // Find the last subtitle index for the given time stamp
-            for (const updateTimestamp of this.updateTimestamps) {
-
-                if (updateTimestamp > time) {
-                    break;
-                }
-                index++;
-            }
-        }
+        const index = PgsRendererHelper.getIndexFromTimestamps(time, this.updateTimestamps);
 
         // Only tell the worker, if the subtitle index was changed!
         if (this.previousTimestampIndex === index) return;

--- a/src/pgsRenderer.ts
+++ b/src/pgsRenderer.ts
@@ -134,15 +134,20 @@ export class PgsRenderer {
     public renderAtTimestamp(time: number): void {
         time = time * 1000 * 90; // Convert to PGS time
 
-        // Find the last subtitle index for the given time stamp
+        // All position before and after the available timestamps are invalid (-1).
         let index = -1;
-        for (const updateTimestamp of this.updateTimestamps) {
+        if (this.updateTimestamps.length > 0 && time < this.updateTimestamps[this.updateTimestamps.length - 1]) {
 
-            if (updateTimestamp > time) {
-                break;
+            // Find the last subtitle index for the given time stamp
+            for (const updateTimestamp of this.updateTimestamps) {
+
+                if (updateTimestamp > time) {
+                    break;
+                }
+                index++;
             }
-            index++;
         }
+
         // Only tell the worker, if the subtitle index was changed!
         if (this.previousTimestampIndex === index) return;
         this.previousTimestampIndex = index;
@@ -163,7 +168,7 @@ export class PgsRenderer {
     private onWorkerMessage = (e: MessageEvent) => {
         switch (e.data.op) {
             // Is called once a subtitle file was loaded.
-            case 'loaded':
+            case 'updateTimestamps':
                 // Stores the update timestamps, so we don't need to push the timestamp to the worker on every tick.
                 // Instead, we push the timestamp index if it was changed.
                 this.updateTimestamps = e.data.updateTimestamps;

--- a/src/pgsRendererHelper.ts
+++ b/src/pgsRendererHelper.ts
@@ -1,0 +1,27 @@
+export class PgsRendererHelper {
+    /**
+     * Returns the array index position for the previous timestamp position from the given array.
+     * Returns -1 if the given time is outside the timestamp range.
+     * @param time The timestamp to check in seconds.
+     * @param pgsTimestamps The list of available PGS timestamps.
+     */
+    public static getIndexFromTimestamps(time: number, pgsTimestamps: number[]): number {
+        const pgsTime = time * 1000 * 90; // Convert to PGS time
+
+        // All position before and after the available timestamps are invalid (-1).
+        let index = -1;
+        if (pgsTimestamps.length > 0 && pgsTime < pgsTimestamps[pgsTimestamps.length - 1]) {
+
+            // Find the last subtitle index for the given time stamp
+            for (const pgsTimestamp of pgsTimestamps) {
+
+                if (pgsTimestamp > pgsTime) {
+                    break;
+                }
+                index++;
+            }
+        }
+
+        return index;
+    }
+}

--- a/src/pgsRendererInternal.ts
+++ b/src/pgsRendererInternal.ts
@@ -207,20 +207,11 @@ export class PgsRendererInternal {
         const canvas = this.createCanvas(width, height);
         const context = canvas.getContext('2d')! as OffscreenCanvasRenderingContext2D | CanvasRenderingContext2D;
         const imageData = context.createImageData(width, height);
-        const buffer = imageData.data;
+        const imageBuffer = new Uint32Array(imageData.data.buffer);
 
         // The pixel data is run-length encoded. The decoded value is the palette entry index.
-        RunLengthEncoding.decode(data, (idx, x, y, value) => {
-            const col = palette?.entries[value];
-            if (!col) return;
+        RunLengthEncoding.decode(data, palette.rgba, imageBuffer);
 
-            // Writing the four byte pixel data as RGBA.
-            buffer[idx * 4] = col.r;
-            buffer[idx * 4 + 1] = col.g;
-            buffer[idx * 4 + 2] = col.b;
-            buffer[idx * 4 + 3] = col.a;
-
-        });
         context.putImageData(imageData, 0, 0);
         return canvas;
     }

--- a/src/renderData.ts
+++ b/src/renderData.ts
@@ -1,0 +1,72 @@
+import {WindowDefinition} from "./pgs/windowDefinitionSegment";
+import {Rect} from "./utils/rect";
+
+/**
+ * This class contains the compiled subtitle data for a whole frame.
+ */
+export class RenderData {
+    /**
+     * The total width of the presentation composition (screen).
+     */
+    public readonly width: number;
+
+    /**
+     * The total height of the presentation composition (screen).
+     */
+    public readonly height: number;
+
+    /**
+     * The pre-compiled composition elements.
+     */
+    public readonly compositionData: CompositionRenderData[];
+
+    public constructor(width: number, height: number, compositionData: CompositionRenderData[]) {
+        this.width = width;
+        this.height = height;
+        this.compositionData = compositionData;
+    }
+
+    /**
+     * Draws the whole subtitle frame to the given context.
+     * @param context The context to draw on.
+     * @param dirtyArea If given, it will extend the dirty rect to include the affected subtitle area.
+     */
+    public draw(context: CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D, dirtyArea?: Rect): void {
+        for (const composition of this.compositionData) {
+            composition.draw(context, dirtyArea);
+        }
+    }
+}
+
+/**
+ * This class contains the compiled subtitle data for a single composition.
+ */
+export class CompositionRenderData {
+    /**
+     * The pgs window to draw on (the on-screen position).
+     */
+    public readonly window: WindowDefinition;
+
+    /**
+     * The compiled pixel data of the subtitle.
+     */
+    public readonly pixelData: HTMLCanvasElement | OffscreenCanvas;
+
+    public constructor(window: WindowDefinition, pixelData: HTMLCanvasElement | OffscreenCanvas) {
+        this.window = window;
+        this.pixelData = pixelData;
+    }
+
+    /**
+     * Draws this subtitle composition to the given context.
+     * @param context The context to draw on.
+     * @param dirtyArea If given, it will extend the dirty rect to include the affected subtitle area.
+     */
+    public draw(context: CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D, dirtyArea?: Rect): void {
+        context.drawImage(this.pixelData, this.window.horizontalPosition, this.window.verticalPosition);
+
+        // Mark this area as dirty.
+        dirtyArea?.union(this.window.horizontalPosition, this.window.verticalPosition,
+            this.pixelData.width, this.pixelData.height);
+    }
+}

--- a/src/utils/arrayBinaryReader.ts
+++ b/src/utils/arrayBinaryReader.ts
@@ -20,6 +20,10 @@ export class ArrayBinaryReader implements BinaryReader {
         return this.array.length;
     }
 
+    public get eof(): boolean {
+        return this.position >= this.length;
+    }
+
     public readByte(): number {
         return this.array[this.$position++];
     }

--- a/src/utils/asyncBinaryReader.ts
+++ b/src/utils/asyncBinaryReader.ts
@@ -1,0 +1,11 @@
+import {BinaryReader} from "./binaryReader";
+
+export interface AsyncBinaryReader extends BinaryReader {
+    /**
+     * Ensures that the given number of bytes is available to read synchronously.
+     * This will wait until the data is ready to read.
+     * @param count The number of bytes requested.
+     * @return Returns if the requested number of bytes could be loaded.
+     */
+    requestData(count: number): Promise<boolean>;
+}

--- a/src/utils/bigEndianBinaryReader.ts
+++ b/src/utils/bigEndianBinaryReader.ts
@@ -5,51 +5,55 @@ export class BigEndianBinaryReader {
     /**
      * The base binary reader.
      */
-    private readonly reader: BinaryReader;
+    public readonly baseReader: BinaryReader;
 
     public constructor(buffer: BinaryReader | Uint8Array) {
         if (buffer instanceof Uint8Array) {
-            this.reader = new ArrayBinaryReader(buffer);
+            this.baseReader = new ArrayBinaryReader(buffer);
         }
         else {
-            this.reader = buffer;
+            this.baseReader = buffer;
         }
     }
 
     public get position(): number {
-        return this.reader.position;
+        return this.baseReader.position;
     }
 
     public get length(): number {
-        return this.reader.length;
+        return this.baseReader.length;
+    }
+
+    public get eof(): boolean {
+        return this.baseReader.eof;
     }
 
     public readUInt8(): number {
-        return this.reader.readByte();
+        return this.baseReader.readByte();
     }
 
     public readUInt16(): number {
-        const b1 = this.reader.readByte();
-        const b2 = this.reader.readByte();
+        const b1 = this.baseReader.readByte();
+        const b2 = this.baseReader.readByte();
         return (b1 << 8) + b2;
     }
 
     public readUInt24(): number {
-        const b1 = this.reader.readByte();
-        const b2 = this.reader.readByte();
-        const b3 = this.reader.readByte();
+        const b1 = this.baseReader.readByte();
+        const b2 = this.baseReader.readByte();
+        const b3 = this.baseReader.readByte();
         return (b1 << 16) + (b2 << 8) + b3;
     }
 
     public readUInt32(): number {
-        const b1 = this.reader.readByte();
-        const b2 = this.reader.readByte();
-        const b3 = this.reader.readByte();
-        const b4 = this.reader.readByte();
+        const b1 = this.baseReader.readByte();
+        const b2 = this.baseReader.readByte();
+        const b3 = this.baseReader.readByte();
+        const b4 = this.baseReader.readByte();
         return (b1 << 24) + (b2 << 16) + (b3 << 8) + b4;
     }
 
     public readBytes(count: number): Uint8Array {
-        return this.reader.readBytes(count);
+        return this.baseReader.readBytes(count);
     }
 }

--- a/src/utils/binaryReader.ts
+++ b/src/utils/binaryReader.ts
@@ -10,6 +10,11 @@ export interface BinaryReader {
     get length(): number;
 
     /**
+     * Gets if the binary reader has reached the end of the data.
+     */
+    get eof(): boolean;
+
+    /**
      * Reads a single byte from this buffer.
      */
     readByte(): number;

--- a/src/utils/combinedBinaryReader.ts
+++ b/src/utils/combinedBinaryReader.ts
@@ -6,7 +6,7 @@ import {ArrayBinaryReader} from "./arrayBinaryReader";
  */
 export class CombinedBinaryReader implements BinaryReader {
     private readonly subReaders: BinaryReader[];
-    private readonly $length: number;
+    private $length: number;
 
     private $position: number = 0;
     private subReaderIndex: number = 0;
@@ -26,12 +26,30 @@ export class CombinedBinaryReader implements BinaryReader {
         this.$length = length;
     }
 
+    /**
+     * Adding another sub-reader to the collection.
+     * @param subReader The new sub-reader to add.
+     */
+    public push(subReader: BinaryReader | Uint8Array) {
+        if (subReader instanceof Uint8Array) {
+            this.subReaders.push(new ArrayBinaryReader(subReader));
+        } else {
+            this.subReaders.push(subReader);
+        }
+
+        this.$length += subReader.length;
+    }
+
     public get position(): number {
         return this.$position;
     }
 
     public get length(): number {
         return this.$length;
+    }
+
+    public get eof(): boolean {
+        return this.position >= this.length;
     }
 
     public readByte(): number {

--- a/src/utils/rect.ts
+++ b/src/utils/rect.ts
@@ -1,0 +1,79 @@
+/**
+ * A simple rectangular class.
+ */
+export class Rect {
+    /**
+     * Gets if the rect is still empty and doesn't contain any area.
+     */
+    public empty: boolean = true;
+
+    /**
+     * Gets the x coordinate of the rectangular area if not empty.
+     */
+    public x: number = 0;
+
+    /**
+     * Gets the y coordinate of the rectangular area if not empty.
+     */
+    public y: number = 0;
+
+    /**
+     * Gets the width of the rectangular area if not empty.
+     */
+    public width: number = 0;
+
+    /**
+     * Gets the height of the rectangular area if not empty.
+     */
+    public height: number = 0;
+
+    /**
+     * Clears the rectangular.
+     */
+    public reset() {
+        this.empty = true;
+        this.x = 0;
+        this.y = 0;
+        this.width = 0;
+        this.height = 0;
+    }
+
+    /**
+     * Grows this rectangular area to include the given area.
+     * @param x The x coordinate of the new area.
+     * @param y The y coordinate of the new area.
+     * @param width The width of the new area. Negative values are not supported.
+     * @param height The height of the new area. Negative values are not supported.
+     */
+    public set(x: number, y: number, width: number = 0, height: number = 0) {
+        this.empty = false;
+        this.x = x;
+        this.y = y;
+        this.width = width;
+        this.height = height;
+    }
+
+    /**
+     * Grows this rectangular area to include the given area.
+     * @param x The x coordinate of the new area to include.
+     * @param y The y coordinate of the new area to include.
+     * @param width The width of the new area to include. Negative values are not supported.
+     * @param height The height of the new area to include. Negative values are not supported.
+     */
+    public union(x: number, y: number, width: number = 0, height: number = 0) {
+        if (this.empty) {
+            // First sub-rect added
+            this.empty = false;
+            this.x = x;
+            this.y = y;
+            this.width = width;
+            this.height = height;
+        } else {
+            // Grow the rectangular area to fit the new sub-rect
+            if (x < this.x) { this.width += this.x - x; this.x = x; }
+            if (y < this.y) { this.height += this.y - y; this.y = y; }
+            if (x + width > this.x + this.width) { this.width = x + width - this.x; }
+            if (y + height > this.y + this.height) { this.height = y + height - this.y; }
+        }
+    }
+}

--- a/src/utils/runLengthEncoding.ts
+++ b/src/utils/runLengthEncoding.ts
@@ -8,29 +8,29 @@ export abstract class RunLengthEncoding {
     /**
      * Decodes the run length encoded image.
      * @param reader The run length encoded binary data reader or buffer.
-     * @param setter This callback is invoked for every pixel and provides the index, coordinate and value.
+     * @param source The source maps the index value to the raw output pixel data.
+     * @param target The pixel data is written to the output.
+     * @return Returns the number of decoded pixels.
      */
-    static decode(reader: BinaryReader | Uint8Array, setter: (idx: number, x: number, y: number, value: number) => void): void {
+    static decode(reader: BinaryReader | Uint8Array,
+        source: number[] | Uint8Array | Uint16Array | Uint32Array,
+        target: number[] | Uint8Array | Uint16Array | Uint32Array): number {
         if (reader instanceof Uint8Array) {
             reader = new ArrayBinaryReader(reader);
         }
 
-        let x = 0;
-        let y = 0;
         let idx = 0;
         while (reader.position < reader.length) {
             const byte1 = reader.readByte();
             // Raw byte
             if (byte1 != 0x00) {
-                setter(idx++, x++, y, byte1);
+                target[idx++] = source[byte1];
                 continue;
             }
 
             const byte2 = reader.readByte();
             // End of line
             if (byte2 == 0x00) {
-                x = 0;
-                y++;
                 continue;
             }
 
@@ -42,8 +42,10 @@ export abstract class RunLengthEncoding {
             }
             const value = bit8 ? reader.readByte() : 0x00;
             for (let i = 0; i < num; i++) {
-                setter(idx++, x++, y, value);
+                target[idx++] = source[value];
             }
         }
+
+        return idx;
     }
 }

--- a/src/utils/streamBinaryReader.ts
+++ b/src/utils/streamBinaryReader.ts
@@ -1,0 +1,54 @@
+import {AsyncBinaryReader} from "./asyncBinaryReader";
+import {CombinedBinaryReader} from "./combinedBinaryReader";
+
+/**
+ * A binary reader based on a readable stream. This can read a partially loaded stream - for example a download.
+ */
+export class StreamBinaryReader implements AsyncBinaryReader {
+    private readonly stream: ReadableStreamDefaultReader<Uint8Array>;
+    private readonly reader: CombinedBinaryReader;
+    private $eof: boolean = false;
+
+    public constructor(stream: ReadableStreamDefaultReader<Uint8Array>) {
+        this.stream = stream;
+        this.reader = new CombinedBinaryReader([]);
+    }
+
+    public get position(): number {
+        return this.reader.position;
+    }
+
+    public get length(): number {
+        return this.reader.length;
+    }
+
+    public get eof(): boolean {
+        return this.$eof;
+    }
+
+    public readByte(): number {
+        return this.reader.readByte();
+    }
+
+    public readBytes(count: number): Uint8Array {
+        return this.reader.readBytes(count);
+    }
+
+    public async requestData(count: number = 0): Promise<boolean> {
+        // Always try to peak one byte ahead to detect end-of-file early
+        while (this.reader.position + count + 1 > this.reader.length && !this.$eof) {
+            let { value, done } = await this.stream.read();
+
+            if (value) {
+                this.reader.push(value);
+            }
+
+            if (done) {
+                this.$eof = true;
+            }
+        }
+
+        // Returns if all data could be requested
+        return this.reader.position + count <= this.reader.length;
+    }
+}

--- a/tests/pgsRenderer.test.ts
+++ b/tests/pgsRenderer.test.ts
@@ -5,14 +5,14 @@
 import {PgsRendererInternal} from "../src/pgsRendererInternal";
 import * as fs from "node:fs";
 
-test('load and render pgs', () => {
+test('load and render pgs', async () => {
     const dataSup = fs.readFileSync(`${__dirname}/files/test.sup`);
 
     const canvas = document.createElement("canvas");
     const context = canvas.getContext("2d")!;
     const renderer = new PgsRendererInternal();
     renderer.setCanvas(canvas);
-    renderer.loadFromBuffer(dataSup);
+    await renderer.loadFromBuffer(dataSup);
 
     // Helper function to render and compare the image in the test directory.
     // Since we only set pixel data and don't use font rendering this should be deterministic on every machine.

--- a/tests/rect.test.ts
+++ b/tests/rect.test.ts
@@ -1,0 +1,63 @@
+import {Rect} from "../src/utils/rect";
+
+test('reset rect', () => {
+    const rect = new Rect();
+    rect.set(1, 1, 2, 2);
+    expect(rect.empty).toBe(false);
+    rect.reset();
+    expect(rect.empty).toBe(true);
+});
+
+test('grow rect in positive x direction', () => {
+    const rect = new Rect();
+
+    rect.set(1, 1, 2, 2);
+    rect.union(5, 1, 2, 2);
+
+    expect(rect.empty).toBe(false);
+    expect(rect.x).toBe(1);
+    expect(rect.y).toBe(1);
+    expect(rect.width).toBe(6);
+    expect(rect.height).toBe(2);
+});
+
+
+test('grow rect in negative x direction', () => {
+    const rect = new Rect();
+
+    rect.set(5, 1, 2, 2);
+    rect.union(1, 1, 2, 2);
+
+    expect(rect.empty).toBe(false);
+    expect(rect.x).toBe(1);
+    expect(rect.y).toBe(1);
+    expect(rect.width).toBe(6);
+    expect(rect.height).toBe(2);
+});
+
+test('grow rect in positive y direction', () => {
+    const rect = new Rect();
+
+    rect.set(1, 1, 2, 2);
+    rect.union(1, 5, 2, 2);
+
+    expect(rect.empty).toBe(false);
+    expect(rect.x).toBe(1);
+    expect(rect.y).toBe(1);
+    expect(rect.width).toBe(2);
+    expect(rect.height).toBe(6);
+});
+
+
+test('grow rect in negative y direction', () => {
+    const rect = new Rect();
+
+    rect.set(1, 5, 2, 2);
+    rect.union(1, 1, 2, 2);
+
+    expect(rect.empty).toBe(false);
+    expect(rect.x).toBe(1);
+    expect(rect.y).toBe(1);
+    expect(rect.width).toBe(2);
+    expect(rect.height).toBe(6);
+});

--- a/tests/runLengthEncoding.test.ts
+++ b/tests/runLengthEncoding.test.ts
@@ -5,30 +5,28 @@ test('2x2 run length decode with linebreak', () => {
         0x01 /* raw byte */, 0x02 /* raw byte */, 0x00, 0x00 /* line break */,
         0x03 /* raw byte */, 0x04 /* raw byte */
     ]);
-    const result: {idx: number, x: number, y: number, value: number}[] = [];
-    RunLengthEncoding.decode(data, (idx, x, y, value) => {
-        result.push({ idx, x, y, value });
-    });
+    const map = [0x00, 0x01, 0x02, 0x03, 0x04];
+    const output = new Uint8Array(4);
+    const length = RunLengthEncoding.decode(data, map, output);
 
-    expect(result.length).toBe(4);
-    expect(result[0]).toMatchObject({ idx: 0, x: 0, y: 0, value: 0x01 });
-    expect(result[1]).toMatchObject({ idx: 1, x: 1, y: 0, value: 0x02 });
-    expect(result[2]).toMatchObject({ idx: 2, x: 0, y: 1, value: 0x03 });
-    expect(result[3]).toMatchObject({ idx: 3, x: 1, y: 1, value: 0x04 });
+    expect(length).toBe(4);
+    expect(output[0]).toBe(0x01);
+    expect(output[1]).toBe(0x02);
+    expect(output[2]).toBe(0x03);
+    expect(output[3]).toBe(0x04);
 });
 
 test('10x1 run length decode with repeating null-byte', () => {
     const data = new Uint8Array([
         0x00, 0x08 /* count */
     ]);
-    const result: {idx: number, x: number, y: number, value: number}[] = [];
-    RunLengthEncoding.decode(data, (idx, x, y, value) => {
-        result.push({ idx, x, y, value });
-    });
+    const map = [0x00];
+    const output = new Uint8Array(8);
+    const length = RunLengthEncoding.decode(data, map, output);
 
-    expect(result.length).toBe(8);
+    expect(length).toBe(8);
     for (let i = 0; i < 8; i++) {
-        expect(result[i]).toMatchObject({ idx: i, x: i, y: 0, value: 0x00 });
+        expect(output[i]).toBe(0x00);
     }
 });
 
@@ -36,14 +34,13 @@ test('10x1 run length decode with repeating byte', () => {
     const data = new Uint8Array([
         0x00, 0x08 /* 6bit count */ | (1 << 7) /* not null byte */, 0x01 /* repeated byte */
     ]);
-    const result: {idx: number, x: number, y: number, value: number}[] = [];
-    RunLengthEncoding.decode(data, (idx, x, y, value) => {
-        result.push({ idx, x, y, value });
-    });
+    const map = [0x00, 0x01];
+    const output = new Uint8Array(8);
+    const length = RunLengthEncoding.decode(data, map, output);
 
-    expect(result.length).toBe(8);
+    expect(length).toBe(8);
     for (let i = 0; i < 8; i++) {
-        expect(result[i]).toMatchObject({ idx: i, x: i, y: 0, value: 0x01 });
+        expect(output[i]).toBe(0x01);
     }
 });
 
@@ -51,14 +48,13 @@ test('522x1 run length decode with repeating null byte', () => {
     const data = new Uint8Array([
         0x00, 0x02 /* higher 6bit count (2x256) */ | (1 << 6) /* 14bit count */, 0x0A /* lower 8bit count (10) */
     ]);
-    const result: {idx: number, x: number, y: number, value: number}[] = [];
-    RunLengthEncoding.decode(data, (idx, x, y, value) => {
-        result.push({ idx, x, y, value });
-    });
+    const map = [0x00];
+    const output = new Uint8Array(522);
+    const length = RunLengthEncoding.decode(data, map, output);
 
-    expect(result.length).toBe(522);
+    expect(length).toBe(522);
     for (let i = 0; i < 522; i++) {
-        expect(result[i]).toMatchObject({ idx: i, x: i, y: 0, value: 0x00 });
+        expect(output[i]).toBe(0x00);
     }
 });
 
@@ -67,13 +63,12 @@ test('522x1 run length decode with repeating byte', () => {
     const data = new Uint8Array([
         0x00, 0x02 /* higher 6bit count (2x256) */ | (1 << 7) /* not null byte */ | (1 << 6) /* 14bit count */, 0x0A /* lower 8bit count (10) */, 0x01 /* repeated byte */
     ]);
-    const result: {idx: number, x: number, y: number, value: number}[] = [];
-    RunLengthEncoding.decode(data, (idx, x, y, value) => {
-        result.push({ idx, x, y, value });
-    });
+    const map = [0x00, 0x01];
+    const output = new Uint8Array(522);
+    const length = RunLengthEncoding.decode(data, map, output);
 
-    expect(result.length).toBe(522);
+    expect(length).toBe(522);
     for (let i = 0; i < 522; i++) {
-        expect(result[i]).toMatchObject({ idx: i, x: i, y: 0, value: 0x01 });
+        expect(output[i]).toBe(0x01);
     }
 });


### PR DESCRIPTION
Some changes to improve rendering performance:
- Only clearing the dirty area with `clearRect`. This really improves clear performance in Firefox.
- Faster run-length-encoding by removing callbacks. This doubled the performance from ~5ms to ~2ms per subtitle.
- Storing rgba values as UInt32 buffer instead of objects.
- Partial pgs stream encoding while downloading. Early subtitles can already be rendered while the rest of the file is still downloading.

