### PR TITLE
Error handling

### DIFF
--- a/src/pgs/displaySet.ts
+++ b/src/pgs/displaySet.ts
@@ -4,7 +4,7 @@ import {PaletteDefinitionSegment} from "./paletteDefinitionSegment";
 import {ObjectDefinitionSegment} from "./objectDefinitionSegment";
 import {WindowDefinitionSegment} from "./windowDefinitionSegment";
 import {SegmentType} from "./segmentType";
-import {AsyncBinaryReader} from "../utils/asyncBinaryReader";
+import {PgsRendererResult} from "../pgsRendererResult";
 
 /**
  * The PGS display set holds all data for the current subtitle update at a given timestamp.
@@ -23,7 +23,7 @@ export class DisplaySet {
      * @param includeHeader If true, the magic-number and timestamps are read. If false, reading starts at the first
      * segment.
      */
-    public async read(reader: BigEndianBinaryReader, includeHeader: boolean) {
+    public async read(reader: BigEndianBinaryReader, includeHeader: boolean): Promise<PgsRendererResult> {
 
         // Clear
         this.presentationTimestamp = 0;
@@ -33,12 +33,6 @@ export class DisplaySet {
         this.objectDefinitions = [];
         this.windowDefinitions = [];
 
-        // Handles async readers
-        let asyncReader: AsyncBinaryReader | undefined = undefined;
-        if ('requestData' in reader.baseReader) {
-            asyncReader = reader.baseReader as AsyncBinaryReader;
-        }
-
         while (true)
         {
             let presentationTimestamp: number = 0;
@@ -47,35 +41,46 @@ export class DisplaySet {
             // The header is included before every segment. Even for the end segment.
             if (includeHeader)
             {
-                await asyncReader?.requestData(10);
+                if (!await reader.requestData(10)) {
+                    console.error(`[libpgs] Unexpected end of stream at 0x${reader.position.toString(16)}`);
+                    return PgsRendererResult.ErrUnexpectedEndOfStream;
+                }
                 const magicNumber = reader.readUInt16();
                 if (magicNumber != 0x5047) {
-                    throw new Error("Invalid magic number!");
+                    console.error(`[libpgs] Invalid magic number: Expected: 0x5047 - Given: 0x${magicNumber.toString(16)}`);
+                    return PgsRendererResult.ErrInvalidMagicNumber;
                 }
 
                 presentationTimestamp = reader.readUInt32();
                 decodingTimestamp = reader.readUInt32();
             }
 
-            await asyncReader?.requestData(3);
-            const type = reader.readUInt8();
-            const size = reader.readUInt16()
+            if (!await reader.requestData(3)) {
+                console.error(`[libpgs] Unexpected end of stream at 0x${reader.position.toString(16)}`);
+                return PgsRendererResult.ErrUnexpectedEndOfStream;
+            }
+            const segmentType = reader.readUInt8();
+            const segmentSize = reader.readUInt16();
+            const segmentStart = reader.position;
 
-            await asyncReader?.requestData(size);
-            switch (type) {
+            if (!await reader.requestData(segmentSize)) {
+                console.error(`[libpgs] Unexpected end of stream at 0x${reader.position.toString(16)}`);
+                return PgsRendererResult.ErrUnexpectedEndOfStream;
+            }
+            switch (segmentType) {
                 case SegmentType.paletteDefinition:
                     const pds = new PaletteDefinitionSegment();
-                    pds.read(reader, size);
+                    pds.read(reader, segmentSize);
                     this.paletteDefinitions.push(pds);
                     break;
                 case SegmentType.objectDefinition:
                     const ods = new ObjectDefinitionSegment();
-                    ods.read(reader, size);
+                    ods.read(reader, segmentSize);
                     this.objectDefinitions.push(ods);
                     break;
                 case SegmentType.presentationComposition:
                     const pcs = new PresentationCompositionSegment();
-                    pcs.read(reader, size);
+                    pcs.read(reader, segmentSize);
                     this.presentationComposition = pcs;
 
                     // SubtitleEdit only writes the relevant timestamp to the PCS.
@@ -84,13 +89,21 @@ export class DisplaySet {
                     break;
                 case SegmentType.windowDefinition:
                     const wds = new WindowDefinitionSegment();
-                    wds.read(reader, size);
+                    wds.read(reader, segmentSize);
                     this.windowDefinitions.push(wds);
                     break;
                 case SegmentType.end:
-                    return;
+                    return PgsRendererResult.Success;
                 default:
-                    throw new Error(`Unsupported segment type ${type}`);
+                    console.error(`[libpgs] Unknown segment type: 0x${segmentType.toString(16)}`);
+                    return PgsRendererResult.ErrUnknownSegment;
+            }
+
+            // Validates the current stream position
+            const expectedPosition = segmentStart + segmentSize;
+            if (reader.position !== expectedPosition) {
+                console.error(`[libpgs] Invalid stream position after segment. Expected: 0x${expectedPosition.toString(16)} - Given: 0x${reader.position.toString(16)}`);
+                return PgsRendererResult.ErrStreamPositionMismatch;
             }
         }
     }

--- a/src/pgsRenderer.ts
+++ b/src/pgsRenderer.ts
@@ -1,5 +1,6 @@
 import {PgsRendererOptions} from "./pgsRendererOptions";
 import {PgsRendererHelper} from "./pgsRendererHelper";
+import {PgsRendererResult} from "./pgsRendererResult";
 
 /**
  * Renders PGS subtitle on-top of a video element using a canvas element. This also handles timestamp updates if a
@@ -154,8 +155,13 @@ export class PgsRenderer {
 
     private onWorkerMessage = (e: MessageEvent) => {
         switch (e.data.op) {
-            // Is called once a subtitle file was loaded.
-            case 'updateTimestamps':
+            // Is called for every progress update of for loading the file.
+            case 'progress':
+                const result = e.data.result as PgsRendererResult;
+                if (result !== PgsRendererResult.Success && result !== PgsRendererResult.Pending) {
+                    console.error(`[libpgs] Couldn't load subtitle stream. Worker returned: ${result}`);
+                }
+
                 // Stores the update timestamps, so we don't need to push the timestamp to the worker on every tick.
                 // Instead, we push the timestamp index if it was changed.
                 this.updateTimestamps = e.data.updateTimestamps;

--- a/src/pgsRendererResult.ts
+++ b/src/pgsRendererResult.ts
@@ -1,0 +1,36 @@
+export enum PgsRendererResult {
+  /**
+   * The renderer has loaded and processed the subtitle stream.
+   */
+  Success,
+
+  /**
+   * The renderer is still processing the subtitle stream.
+   */
+  Pending,
+
+  /**
+   * Processing the subtitle stream failed due to an invalid magic number. Probably not a PGS file.
+   */
+  ErrInvalidMagicNumber,
+
+  /**
+   * Processing the subtitle stream failed due to an unexpected end of the stream.
+   */
+  ErrUnexpectedEndOfStream,
+
+  /**
+   * Processing the subtitle stream failed due to an unknown segment type.
+   */
+  ErrUnknownSegment,
+
+  /**
+   * Processing the subtitle stream failed due to a stream position mismatch after reading a segment.
+   */
+  ErrStreamPositionMismatch,
+
+  /**
+   * Loading the subtitle stream failed due to an HTTP error.
+   */
+  ErrHttp
+}

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -1,11 +1,13 @@
 import {PgsRendererInternal} from "./pgsRendererInternal";
+import {PgsRendererResult} from "./pgsRendererResult";
 
 const renderer = new PgsRendererInternal();
 
-// Inform the main process that the subtitle data was loaded and return all update timestamps
-const submitTimestamps = () => {
+// Inform the main process about the renderer status update.
+const sendProgressUpdate = (result: PgsRendererResult) => {
     postMessage({
-        op: 'updateTimestamps',
+        op: 'progress',
+        result: result,
         updateTimestamps: renderer.updateTimestamps
     })
 }
@@ -22,17 +24,17 @@ onmessage = (e: MessageEvent) => {
             const url: string = e.data.url;
             renderer.loadFromUrl(url, {
                 onProgress: () => {
-                    submitTimestamps();
+                    sendProgressUpdate(PgsRendererResult.Pending);
                 }
-            }).then(() => {
-                submitTimestamps();
+            }).then((result) => {
+                sendProgressUpdate(result);
             });
             break;
 
         case 'loadFromBuffer':
             const buffer: ArrayBuffer = e.data.buffer;
-            renderer.loadFromBuffer(buffer).then(() => {
-                submitTimestamps();
+            renderer.loadFromBuffer(buffer).then((result) => {
+                sendProgressUpdate(result);
             });
 
             break;

--- a/tests/pgsRenderer.test.ts
+++ b/tests/pgsRenderer.test.ts
@@ -4,6 +4,7 @@
 
 import {PgsRendererInternal} from "../src/pgsRendererInternal";
 import * as fs from "node:fs";
+import {PgsRendererResult} from "../src/pgsRendererResult";
 
 test('load and render pgs', async () => {
     const dataSup = fs.readFileSync(`${__dirname}/files/test.sup`);
@@ -12,7 +13,8 @@ test('load and render pgs', async () => {
     const context = canvas.getContext("2d")!;
     const renderer = new PgsRendererInternal();
     renderer.setCanvas(canvas);
-    await renderer.loadFromBuffer(dataSup);
+    const result = await renderer.loadFromBuffer(dataSup);
+    expect(result).toBe(PgsRendererResult.Success);
 
     // Helper function to render and compare the image in the test directory.
     // Since we only set pixel data and don't use font rendering this should be deterministic on every machine.
@@ -33,3 +35,13 @@ test('load and render pgs', async () => {
     expectImageAtTimestamp('test-1.rgba', 2.5);
     expectImageAtTimestamp('test-2.rgba', 3.5);
 });
+
+test('load non-pgs file and catch error', async () => {
+    const consoleErrorMock = jest.spyOn(console, 'error').mockImplementation();
+
+    const dataSup = fs.readFileSync(`${__dirname}/files/test.srt`);
+    const renderer = new PgsRendererInternal();
+    const result = await renderer.loadFromBuffer(dataSup);
+    expect(result).toBe(PgsRendererResult.ErrInvalidMagicNumber);
+    expect(consoleErrorMock).toHaveBeenCalled();
+})


### PR DESCRIPTION
This PR adds error handing to the internal worker renderer. If there are any parsing errors when reading the subtitle stream, the renderer should not crash and continue to work. At least with the currently obtained data. 

This catches:
- Invalid magic numbers (non PGS files)
- HTTP errors
- Unexpected end of streams
- Unknown PGS segments 