### PR TITLE
WebOS compatibility

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "libpgs",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "libpgs",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "license": "MIT",
       "devDependencies": {
         "@rollup/plugin-commonjs": "^26.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,18 +9,22 @@
       "version": "0.5.0",
       "license": "MIT",
       "devDependencies": {
+        "@rollup/plugin-commonjs": "^26.0.1",
+        "@rollup/plugin-node-resolve": "^15.2.3",
         "@rollup/plugin-terser": "^0.4.4",
         "@rollup/plugin-typescript": "^11.1.6",
         "@tsconfig/recommended": "^1.0.6",
         "@types/jest": "^29.5.12",
         "canvas": "^2.11.2",
+        "core-js": "^3.38.1",
         "jest": "^29.7.0",
         "jest-environment-jsdom": "^29.7.0",
         "rollup": "^4.18.0",
         "ts-jest": "^29.1.4",
         "ts-node": "^10.9.2",
         "tslib": "^2.6.3",
-        "typescript": "^5.4.5"
+        "typescript": "^5.4.5",
+        "whatwg-fetch": "^3.6.20"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -692,6 +696,109 @@
         "node": ">=12"
       }
     },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/ansi-regex": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
+      "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/ansi-styles": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
+      "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@isaacs/cliui/node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/strip-ansi": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
+      "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
     "node_modules/@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
@@ -1129,9 +1236,9 @@
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.4.15",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
-      "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
+      "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -1191,6 +1298,126 @@
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@rollup/plugin-commonjs": {
+      "version": "26.0.1",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-26.0.1.tgz",
+      "integrity": "sha512-UnsKoZK6/aGIH6AdkptXhNvhaqftcjq3zZdT+LY5Ftms6JR06nADcDsYp5hTU9E2lbJUEOhdlY5J4DNTneM+jQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rollup/pluginutils": "^5.0.1",
+        "commondir": "^1.0.1",
+        "estree-walker": "^2.0.2",
+        "glob": "^10.4.1",
+        "is-reference": "1.2.1",
+        "magic-string": "^0.30.3"
+      },
+      "engines": {
+        "node": ">=16.0.0 || 14 >= 14.17"
+      },
+      "peerDependencies": {
+        "rollup": "^2.68.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rollup/plugin-commonjs/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@rollup/plugin-commonjs/node_modules/glob": {
+      "version": "10.4.5",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
+      "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@rollup/plugin-commonjs/node_modules/minimatch": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@rollup/plugin-commonjs/node_modules/minipass": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
+      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/@rollup/plugin-node-resolve": {
+      "version": "15.2.3",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-15.2.3.tgz",
+      "integrity": "sha512-j/lym8nf5E21LwBT4Df1VD6hRO2L2iwUeUmP7litikRsVp1H6NWx20NEp0Y7su+7XGc476GnXXc4kFeZNGmaSQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rollup/pluginutils": "^5.0.1",
+        "@types/resolve": "1.20.2",
+        "deepmerge": "^4.2.2",
+        "is-builtin-module": "^3.2.1",
+        "is-module": "^1.0.0",
+        "resolve": "^1.22.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^2.78.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
       }
     },
     "node_modules/@rollup/plugin-terser": {
@@ -1684,6 +1911,13 @@
         "undici-types": "~5.26.4"
       }
     },
+    "node_modules/@types/resolve": {
+      "version": "1.20.2",
+      "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.20.2.tgz",
+      "integrity": "sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/stack-utils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
@@ -2096,6 +2330,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/builtin-modules": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.3.0.tgz",
+      "integrity": "sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -2309,6 +2556,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/commondir": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
+      "integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -2329,6 +2583,18 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/core-js": {
+      "version": "3.38.1",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.38.1.tgz",
+      "integrity": "sha512-OP35aUorbU3Zvlx7pjsFdu1rGNnD4pgw/CWoYzRY3t2EzoVT7shKHY1dlAy3f41cGIO7ZDPQimhGFTlEYkG/Hw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
     },
     "node_modules/create-jest": {
       "version": "29.7.0",
@@ -2597,6 +2863,13 @@
         "node": ">=12"
       }
     },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.4.792",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.792.tgz",
@@ -2822,6 +3095,36 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/foreground-child": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.0.tgz",
+      "integrity": "sha512-Ld2g8rrAyMYFXBhEqMz8ZAHBi4J4uS1i/CxGMDnjyFWddMXLVcDp051DZfu+t7+ab7Wv6SMqpWmyFIj5UbfFvg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.0",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/foreground-child/node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/form-data": {
@@ -3166,6 +3469,22 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/is-builtin-module": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-3.2.1.tgz",
+      "integrity": "sha512-BSLE3HnV2syZ0FK0iMA/yUGplUeMmNz4AW5fnTunbCIqZi4vG3WjJT9FHMy5D69xmAYBHXQhJdALdpwVxV501A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "builtin-modules": "^3.3.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-core-module": {
       "version": "2.13.1",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.13.1.tgz",
@@ -3199,6 +3518,13 @@
         "node": ">=6"
       }
     },
+    "node_modules/is-module": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-module/-/is-module-1.0.0.tgz",
+      "integrity": "sha512-51ypPSPCoTEIN9dy5Oy+h4pShgJmPCygKfyRCISBI+JoWT/2oJvK8QPxmwv7b/p239jXrm9M1mlQbyKJ5A152g==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -3215,6 +3541,16 @@
       "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/is-reference": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-1.2.1.tgz",
+      "integrity": "sha512-U82MsXXiFIrjCK4otLT+o2NA2Cd2g5MLoOVXUZjIOhLurrRxpEXzI8O0KZHr3IjLvlAH1kTPYSuqer5T9ZVBKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "*"
+      }
     },
     "node_modules/is-stream": {
       "version": "2.0.1",
@@ -3318,6 +3654,22 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
       }
     },
     "node_modules/jest": {
@@ -4184,6 +4536,16 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/magic-string": {
+      "version": "0.30.11",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.11.tgz",
+      "integrity": "sha512-+Wri9p0QHMy+545hKww7YAu5NyzF8iomPL/RQazugQ9+Ez4Ic3mERMd8ZTX5rfK944j+560ZJi8iAwgak1Ac7A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0"
+      }
+    },
     "node_modules/make-dir": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
@@ -4225,9 +4587,9 @@
       "license": "MIT"
     },
     "node_modules/micromatch": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.7.tgz",
-      "integrity": "sha512-LPP/3KorzCwBxfeUuZmaR6bG2kdeHSbe0P2tY3FLRU4vYrjYz5hI4QZwV0njUx3jeuKe67YukQ1LSPZBKDqO/Q==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4545,6 +4907,13 @@
         "node": ">=6"
       }
     },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.0.tgz",
+      "integrity": "sha512-dATvCeZN/8wQsGywez1mzHtTlP22H8OEfPrVMLNr4/eGa+ijtLn/6M5f0dY8UKNrC2O9UCU6SSoG3qRKnt7STw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0"
+    },
     "node_modules/parse-json": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
@@ -4613,6 +4982,30 @@
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/path-scurry/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/picocolors": {
       "version": "1.0.1",
@@ -5131,7 +5524,37 @@
         "node": ">=8"
       }
     },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
@@ -5603,6 +6026,13 @@
         "node": ">=12"
       }
     },
+    "node_modules/whatwg-fetch": {
+      "version": "3.6.20",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.20.tgz",
+      "integrity": "sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/whatwg-mimetype": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
@@ -5651,6 +6081,25 @@
       }
     },
     "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",

--- a/package.json
+++ b/package.json
@@ -27,17 +27,21 @@
     "clear": "rm -rf ./dist"
   },
   "devDependencies": {
+    "@rollup/plugin-commonjs": "^26.0.1",
+    "@rollup/plugin-node-resolve": "^15.2.3",
     "@rollup/plugin-terser": "^0.4.4",
     "@rollup/plugin-typescript": "^11.1.6",
     "@tsconfig/recommended": "^1.0.6",
     "@types/jest": "^29.5.12",
     "canvas": "^2.11.2",
+    "core-js": "^3.38.1",
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^29.7.0",
     "rollup": "^4.18.0",
     "ts-jest": "^29.1.4",
     "ts-node": "^10.9.2",
     "tslib": "^2.6.3",
-    "typescript": "^5.4.5"
+    "typescript": "^5.4.5",
+    "whatwg-fetch": "^3.6.20"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "libpgs",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "author": "David Schulte",
   "license": "MIT",
   "description": "Renderer for graphical subtitles (PGS) in the browser. ",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,5 +1,7 @@
 import typescript from "@rollup/plugin-typescript";
 import terser from '@rollup/plugin-terser';
+import commonjs from "@rollup/plugin-commonjs";
+import nodeResolve from "@rollup/plugin-node-resolve";
 
 const typescriptOptions = {
     compilerOptions: {
@@ -19,7 +21,12 @@ export default [
             file: 'dist/libpgs.js',
             format: 'es'
         },
-        plugins: [terser(terserOptions), typescript(typescriptOptions)]
+        plugins: [
+            terser(terserOptions),
+            typescript(typescriptOptions),
+            commonjs(),
+            nodeResolve()
+        ]
     },
     {
         input: 'src/worker.ts',
@@ -27,6 +34,11 @@ export default [
             file: 'dist/libpgs.worker.js',
             format: 'es'
         },
-        plugins: [terser(terserOptions), typescript(typescriptOptions)]
+        plugins: [
+            terser(terserOptions),
+            typescript(typescriptOptions),
+            commonjs(),
+            nodeResolve()
+        ]
     }
 ];

--- a/src/browserSupport.ts
+++ b/src/browserSupport.ts
@@ -1,0 +1,71 @@
+import {PgsRendererMode} from "./pgsRendererMode";
+
+export class BrowserSupport {
+    /**
+     * Checks if the web worker is supported in the current environment.
+     */
+    public static isWorkerSupported(): boolean {
+        return !!Worker;
+    }
+
+    /**
+     * Checks if the offscreen-canvas and `transferControlToOffscreen` are supported in the current environment.
+     */
+    public static isOffscreenCanvasSupported(): boolean {
+        return !!HTMLCanvasElement.prototype.transferControlToOffscreen;
+    }
+
+    /**
+     * Returns the optimal PGS renderer mode for the current platform.
+     */
+    public static getRendererModeByPlatform(): PgsRendererMode {
+        // Handle browser specific edge cases. This list is not complete!
+        // If you find any more compatible issues with legacy browsers, please report them on the issue tracker.
+        const userAgent = navigator.userAgent;
+
+        // Detect Chrome
+        const chrome = /Chrome\/(\d+)/.exec(userAgent);
+        const chromeVersion = chrome ? parseInt(chrome[1]) : undefined;
+
+        // Detect Firefox
+        const firefox = /Firefox\/(\d+)/.exec(userAgent);
+        const firefoxVersion = firefox ? parseInt(firefox[1]) : undefined;
+
+        // Detect WebOS
+        const webOS = navigator.userAgent.indexOf('Web0S') >= 0;
+
+
+        // ImageData in workers is supported since Chrome 36
+        if (chromeVersion && chromeVersion < 36) {
+            return PgsRendererMode.mainThread;
+        }
+
+        // ImageData in workers is supported since Firefox 25
+        if (firefoxVersion && firefoxVersion < 25) {
+            return PgsRendererMode.mainThread;
+        }
+
+        // Older version of WebOS are based on WebKit and don't support ImageData in Workers.
+        if (webOS && chromeVersion === undefined) {
+            return PgsRendererMode.mainThread;
+        }
+        // WebOS 5 / Chrome 68 should support workers, but they do not load nor respond to messages.
+        if (webOS && chromeVersion && chromeVersion <= 68) {
+            return PgsRendererMode.mainThread;
+        }
+
+
+        // Detect by features
+        const isWorkerSupported = this.isWorkerSupported();
+        const isOffscreenCanvasSupported = this.isOffscreenCanvasSupported();
+        if (isWorkerSupported) {
+            if (isOffscreenCanvasSupported) {
+                return PgsRendererMode.worker;
+            } else {
+                return PgsRendererMode.workerWithoutOffscreenCanvas;
+            }
+        } else {
+            return PgsRendererMode.mainThread;
+        }
+    }
+}

--- a/src/libpgs.ts
+++ b/src/libpgs.ts
@@ -1,2 +1,6 @@
+// Polyfills
+import "core-js/stable/promise";
+import "whatwg-fetch";
+
 import {PgsRenderer} from "./pgsRenderer";
 export {PgsRenderer}

--- a/src/pgs.ts
+++ b/src/pgs.ts
@@ -13,11 +13,11 @@ import {WindowDefinition} from "./pgs/windowDefinitionSegment";
 import {PgsRendererHelper} from "./pgsRendererHelper";
 
 export interface PgsLoadOptions {
-  /**
-   * Async pgs streams can return partial updates. When invoked, the `displaySets` and `updateTimestamps` are updated
-   * to the last available subtitle. There is a minimum threshold of one-second to prevent to many updates.
-   */
-  onProgress?: () => void;
+    /**
+     * Async pgs streams can return partial updates. When invoked, the `displaySets` and `updateTimestamps` are updated
+     * to the last available subtitle. There is a minimum threshold of one-second to prevent to many updates.
+     */
+    onProgress?: () => void;
 }
 
 /**
@@ -26,200 +26,227 @@ export interface PgsLoadOptions {
  */
 export class Pgs {
 
-  /**
-   * The currently loaded display sets.
-   */
-  public displaySets: DisplaySet[] = [];
+    /**
+     * The currently loaded display sets.
+     */
+    public displaySets: DisplaySet[] = [];
 
-  /**
-   * The PGS timestamps when a display set with the same index is presented.
-   */
-  public updateTimestamps: number[] = [];
+    /**
+     * The PGS timestamps when a display set with the same index is presented.
+     */
+    public updateTimestamps: number[] = [];
 
-  /**
-   * Loads the subtitle file from the given url.
-   * @param url The url to the PGS file.
-   * @param options Optional loading options. Use `onProgress` as callback for partial update while loading.
-   */
-  public async loadFromUrl(url: string, options?: PgsLoadOptions): Promise<void> {
-    const response = await fetch(url);
-    if (!response.ok) {
-      throw new Error(`HTTP error: ${response.status}`);
-    }
-    const stream = response.body?.getReader()!;
-    const reader = new StreamBinaryReader(stream)
-
-    await this.loadFromReader(reader, options);
-  }
-
-  /**
-   * Loads the subtitle file from the given buffer.
-   * @param buffer The PGS data.
-   * @param options Optional loading options. Use `onProgress` as callback for partial update while loading.
-   */
-  public async loadFromBuffer(buffer: ArrayBuffer, options?: PgsLoadOptions): Promise<void> {
-    await this.loadFromReader(new ArrayBinaryReader(new Uint8Array(buffer)), options);
-  }
-
-  /**
-   * Loads the subtitle file from the given buffer.
-   * @param reader The PGS data reader.
-   * @param options Optional loading options. Use `onProgress` as callback for partial update while loading.
-   */
-  public async loadFromReader(reader: BinaryReader, options?: PgsLoadOptions): Promise<void> {
-    this.displaySets = [];
-    this.updateTimestamps = [];
-    this.cachedSubtitleData = undefined;
-
-    let lastUpdateTime = performance.now();
-
-    const bigEndianReader = new BigEndianBinaryReader(reader);
-    while (!reader.eof) {
-      const displaySet = new DisplaySet();
-      await displaySet.read(bigEndianReader, true);
-      this.displaySets.push(displaySet);
-      this.updateTimestamps.push(displaySet.presentationTimestamp);
-
-      // For async loading, we support frequent progress updates. Sending one update for every new display set
-      // would be too much. Instead, we use a one-second threshold.
-      if (options?.onProgress) {
-        let now = performance.now();
-        if (now > lastUpdateTime + 1000) {
-          lastUpdateTime = now;
-          options.onProgress();
+    /**
+     * Loads the subtitle file from the given url.
+     * @param url The url to the PGS file.
+     * @param options Optional loading options. Use `onProgress` as callback for partial update while loading.
+     */
+    public async loadFromUrl(url: string, options?: PgsLoadOptions): Promise<void> {
+        const response = await fetch(url);
+        if (!response.ok) {
+            throw new Error(`HTTP error: ${response.status}`);
         }
-      }
+        // The `body` and therefore readable streams are only available since Chrome 105. With this available we can utilize
+        // partial reading while downloading. As a fallback we wait for the whole file to download before reading.
+        const stream = response.body?.getReader();
+        let reader: BinaryReader;
+        if (stream) {
+            reader = new StreamBinaryReader(stream);
+        } else {
+            const buffer = await response.arrayBuffer();
+            reader = new ArrayBinaryReader(new Uint8Array(buffer));
+        }
+
+        await this.loadFromReader(reader, options);
     }
 
-    // Call final update.
-    if (options?.onProgress) {
-      options.onProgress();
-    }
-  }
-
-  // Information about the next compiled subtitle data. This is calculated after the current subtitle is rendered.
-  // So by the time the next subtitle change is requested, this should already be completed.
-  private cachedSubtitleData?: { index: number, data: SubtitleData | undefined };
-
-
-  /**
-   * Pre-compiles and caches the subtitle data for the given index.
-   * This will speed up the next call to `buildSubtitleDataAtIndex` with the same index.
-   * @param index The index of the display set to cache.
-   */
-  public cacheSubtitleAtIndex(index: number) {
-    // Pre-calculating the next subtitle, so it is ready whenever the next subtitle change is requested.
-    const nextSubtitleData = this.getSubtitleAtIndex(index);
-    this.cachedSubtitleData = { index: index, data: nextSubtitleData };
-  }
-
-  /**
-   * Renders the subtitle at the given timestamp.
-   * @param time The timestamp in seconds.
-   */
-  public getSubtitleAtTimestamp(time: number): SubtitleData | undefined {
-    const index = PgsRendererHelper.getIndexFromTimestamps(time, this.updateTimestamps);
-    return this.getSubtitleAtIndex(index);
-  }
-
-  /**
-   * Pre-compiles the required subtitle data (windows and pixel data) for the frame at the given index.
-   * @param index The index of the display set to render.
-   */
-  public getSubtitleAtIndex(index: number): SubtitleData | undefined {
-    // Check if this index was already cached.
-    if (this.cachedSubtitleData && this.cachedSubtitleData.index === index) {
-      return this.cachedSubtitleData.data;
+    /**
+     * Loads the subtitle file from the given buffer.
+     * @param buffer The PGS data.
+     * @param options Optional loading options. Use `onProgress` as callback for partial update while loading.
+     */
+    public async loadFromBuffer(buffer: ArrayBuffer, options?: PgsLoadOptions): Promise<void> {
+        await this.loadFromReader(new ArrayBinaryReader(new Uint8Array(buffer)), options);
     }
 
-    if (index < 0 || index >= this.displaySets.length) {
-      return;
+    /**
+     * Loads the subtitle file from the given buffer.
+     * @param reader The PGS data reader.
+     * @param options Optional loading options. Use `onProgress` as callback for partial update while loading.
+     */
+    public async loadFromReader(reader: BinaryReader, options?: PgsLoadOptions): Promise<void> {
+        this.displaySets = [];
+        this.updateTimestamps = [];
+        this.cachedSubtitleData = undefined;
+
+        let lastUpdateTime = performance.now();
+
+        const bigEndianReader = new BigEndianBinaryReader(reader);
+        while (!reader.eof) {
+            const displaySet = new DisplaySet();
+            await displaySet.read(bigEndianReader, true);
+            this.displaySets.push(displaySet);
+            this.updateTimestamps.push(displaySet.presentationTimestamp);
+
+            // For async loading, we support frequent progress updates. Sending one update for every new display set
+            // would be too much. Instead, we use a one-second threshold.
+            if (options?.onProgress) {
+                let now = performance.now();
+                if (now > lastUpdateTime + 1000) {
+                    lastUpdateTime = now;
+                    options.onProgress();
+                }
+            }
+        }
+
+        // Call final update.
+        if (options?.onProgress) {
+            options.onProgress();
+        }
     }
 
-    const displaySet = this.displaySets[index];
-    if (!displaySet.presentationComposition) return;
+    // Information about the next compiled subtitle data. This is calculated after the current subtitle is rendered.
+    // So by the time the next subtitle change is requested, this should already be completed.
+    private cachedSubtitleData?: { index: number, data: SubtitleData | undefined };
 
-    // We need to collect all valid objects and palettes up to this point. PGS can update and reuse elements from
-    // previous display sets. The `compositionState` defines if the previous elements should be cleared.
-    // If it is `0` previous elements should be kept. Because the user can seek through the file, we can not store
-    // previous elements, and we should collect these elements for every new render.
-    const ctxObjects: ObjectDefinitionSegment[] = [];
-    const ctxPalettes: PaletteDefinitionSegment[] = [];
-    const ctxWindows: WindowDefinition[] = [];
-    let curIndex = index;
-    while (curIndex >= 0) {
-      // Because we are moving backwards, we would end up with the inverted array order.
-      // We'll use `unshift` to add these elements to the front of the array.
-      ctxObjects.unshift(...this.displaySets[curIndex].objectDefinitions);
-      ctxPalettes.unshift(...this.displaySets[curIndex].paletteDefinitions);
-      ctxWindows.unshift(...this.displaySets[curIndex].windowDefinitions
-        .flatMap(w => w.windows));
 
-      // Any other state that `0` frees all previous segments, so we can stop here.
-      if (this.displaySets[curIndex].presentationComposition?.compositionState !== 0) {
-        break;
-      }
-
-      curIndex--;
+    /**
+     * Pre-compiles and caches the subtitle data for the given index.
+     * This will speed up the next call to `buildSubtitleDataAtIndex` with the same index.
+     * @param index The index of the display set to cache.
+     */
+    public cacheSubtitleAtIndex(index: number) {
+        // Pre-calculating the next subtitle, so it is ready whenever the next subtitle change is requested.
+        const nextSubtitleData = this.getSubtitleAtIndex(index);
+        this.cachedSubtitleData = { index: index, data: nextSubtitleData };
     }
 
-    // Find the used palette for this composition.
-    let palette = ctxPalettes
-      .find(w => w.id === displaySet.presentationComposition?.paletteId);
-    if (!palette) return;
-
-    const compositionData: SubtitleCompositionData[] = [];
-    for (const compositionObject of displaySet.presentationComposition.compositionObjects) {
-      // Find the window to draw on.
-      let window = ctxWindows.find(w => w.id === compositionObject.windowId);
-      if (!window) continue;
-
-      // Builds the subtitle.
-      const pixelData = this.getPixelDataFromComposition(compositionObject, palette, ctxObjects);
-      if (pixelData) {
-        compositionData.push(new SubtitleCompositionData(window, pixelData));
-      }
+    /**
+     * Renders the subtitle at the given timestamp.
+     * @param time The timestamp in seconds.
+     */
+    public getSubtitleAtTimestamp(time: number): SubtitleData | undefined {
+        const index = PgsRendererHelper.getIndexFromTimestamps(time, this.updateTimestamps);
+        return this.getSubtitleAtIndex(index);
     }
 
-    if (compositionData.length === 0) return;
+    /**
+     * Pre-compiles the required subtitle data (windows and pixel data) for the frame at the given index.
+     * @param index The index of the display set to render.
+     */
+    public getSubtitleAtIndex(index: number): SubtitleData | undefined {
+        // Check if this index was already cached.
+        if (this.cachedSubtitleData && this.cachedSubtitleData.index === index) {
+            return this.cachedSubtitleData.data;
+        }
 
-    return new SubtitleData(displaySet.presentationComposition.width, displaySet.presentationComposition.height,
-      compositionData);
-  }
+        if (index < 0 || index >= this.displaySets.length) {
+            return;
+        }
 
+        const displaySet = this.displaySets[index];
+        if (!displaySet.presentationComposition) return;
 
-  private getPixelDataFromComposition(composition: CompositionObject, palette: PaletteDefinitionSegment,
-                                      ctxObjects: ObjectDefinitionSegment[]): ImageData | undefined {
-    // Multiple object definition can define a single subtitle image.
-    // However, only the first element in sequence hold the image size.
-    let width: number = 0;
-    let height: number = 0;
-    const dataChunks: Uint8Array[] = [];
-    for (const ods of ctxObjects) {
-      if (ods.id != composition.id) continue;
-      if (ods.isFirstInSequence) {
-        width = ods.width;
-        height = ods.height;
-      }
+        // We need to collect all valid objects and palettes up to this point. PGS can update and reuse elements from
+        // previous display sets. The `compositionState` defines if the previous elements should be cleared.
+        // If it is `0` previous elements should be kept. Because the user can seek through the file, we can not store
+        // previous elements, and we should collect these elements for every new render.
+        const ctxObjects: ObjectDefinitionSegment[] = [];
+        const ctxPalettes: PaletteDefinitionSegment[] = [];
+        const ctxWindows: WindowDefinition[] = [];
+        let curIndex = index;
+        while (curIndex >= 0) {
+            const displaySet = this.displaySets[curIndex];
+            // Because we are moving backwards, we would end up with the inverted array order.
+            // We'll use `unshift` to add these elements to the front of the array.
+            ctxObjects.unshift(...displaySet.objectDefinitions);
+            ctxPalettes.unshift(...displaySet.paletteDefinitions);
+            // `flatMap` is available since Chrome 69.
+            for (const windowDefinition of displaySet.windowDefinitions) {
+                ctxWindows.unshift(...windowDefinition.windows);
+            }
 
-      if (ods.data) {
-        dataChunks.push(ods.data);
-      }
+            // Any other state that `0` frees all previous segments, so we can stop here.
+            if (this.displaySets[curIndex].presentationComposition?.compositionState !== 0) {
+                break;
+            }
+
+            curIndex--;
+        }
+
+        // Find the used palette for this composition.
+        let palette = ctxPalettes
+            .find(w => w.id === displaySet.presentationComposition?.paletteId);
+        if (!palette) return;
+
+        const compositionData: SubtitleCompositionData[] = [];
+        for (const compositionObject of displaySet.presentationComposition.compositionObjects) {
+            // Find the window to draw on.
+            let window = ctxWindows.find(w => w.id === compositionObject.windowId);
+            if (!window) continue;
+
+            // Builds the subtitle.
+            const pixelData = this.getPixelDataFromComposition(compositionObject, palette, ctxObjects);
+            if (pixelData) {
+                compositionData.push(new SubtitleCompositionData(window, pixelData));
+            }
+        }
+
+        if (compositionData.length === 0) return;
+
+        return new SubtitleData(displaySet.presentationComposition.width, displaySet.presentationComposition.height,
+            compositionData);
     }
-    if (dataChunks.length == 0) {
-      return undefined;
+
+
+    private getPixelDataFromComposition(composition: CompositionObject, palette: PaletteDefinitionSegment,
+                                        ctxObjects: ObjectDefinitionSegment[]): ImageData | undefined {
+        // Multiple object definition can define a single subtitle image.
+        // However, only the first element in sequence hold the image size.
+        let width: number = 0;
+        let height: number = 0;
+        const dataChunks: Uint8Array[] = [];
+        for (const ods of ctxObjects) {
+            if (ods.id != composition.id) continue;
+            if (ods.isFirstInSequence) {
+                width = ods.width;
+                height = ods.height;
+            }
+
+            if (ods.data) {
+                dataChunks.push(ods.data);
+            }
+        }
+        if (dataChunks.length == 0) {
+            return undefined;
+        }
+
+        // Using a combined reader instead of stitching the data together.
+        // This hopefully avoids a larger memory allocation.
+        const data = new CombinedBinaryReader(dataChunks);
+
+        // Detect if we are running in a web-worker or in main browser
+        if (typeof document !== 'undefined') {
+            // We have to use the canvas api to create image data.
+            const canvas = document.createElement("canvas");
+            const context = canvas.getContext("2d")!;
+            const imageData = context.createImageData(width, height);
+            const imageBuffer = new Uint32Array(imageData.data.buffer);
+
+            // The pixel data is run-length encoded. The decoded value is the palette entry index.
+            RunLengthEncoding.decode(data, palette.rgba, imageBuffer);
+
+            return imageData;
+        } else {
+            // Building a canvas element with the subtitle image data.
+            const imageBuffer = new Uint32Array(width * height);
+
+            // The pixel data is run-length encoded. The decoded value is the palette entry index.
+            RunLengthEncoding.decode(data, palette.rgba, imageBuffer);
+
+            // We can use the image data constructor in web-workers.
+            return new ImageData(new Uint8ClampedArray(imageBuffer.buffer), width, height);
+        }
     }
 
-    // Using a combined reader instead of stitching the data together.
-    // This hopefully avoids a larger memory allocation.
-    const data = new CombinedBinaryReader(dataChunks);
-
-    // Building a canvas element with the subtitle image data.
-    const imageBuffer = new Uint32Array(width * height);
-
-    // The pixel data is run-length encoded. The decoded value is the palette entry index.
-    RunLengthEncoding.decode(data, palette.rgba, imageBuffer);
-
-    return new ImageData(new Uint8ClampedArray(imageBuffer.buffer), width, height);
-  }
 }

--- a/src/pgsRendererImpl.ts
+++ b/src/pgsRendererImpl.ts
@@ -7,13 +7,28 @@ import {PgsRendererHelper} from "./pgsRendererHelper";
  */
 export abstract class PgsRendererImpl {
 
-    protected updateTimestamps: number[] = [];
+    private updateTimestamps: number[] = [];
     private previousTimestampIndex: number = 0;
 
     /**
      * Is called when the timestamps were updated.
      */
     public onTimestampsUpdated?: () => void;
+
+    /**
+     * Sets the update timestamps and invokes an update event.
+     * @param updateTimestamps The new array of update timestamps.
+     */
+    protected setUpdateTimestamps(updateTimestamps: number[]): void {
+        // Stores the update timestamps, so we don't need to push the timestamp to the worker on every tick.
+        // Instead, we push the timestamp index if it was changed.
+        this.updateTimestamps = updateTimestamps;
+
+        // Notify timestamp updates.
+        if (this.onTimestampsUpdated) {
+            this.onTimestampsUpdated();
+        }
+    }
 
     /**
      * Renders the subtitle for the given timestamp.

--- a/src/pgsRendererInMainThread.ts
+++ b/src/pgsRendererInMainThread.ts
@@ -1,0 +1,67 @@
+import {PgsRendererImpl} from "./pgsRendererImpl";
+import {PgsRendererOptions} from "./pgsRendererOptions";
+import {Renderer} from "./renderer";
+import {Pgs} from "./pgs";
+
+/**
+ * The implementation without web workers. This loads and renders the subtitle in the main thread.
+ * This is meant as a compatibility fallback if advanced workers are not supported.
+ */
+export class PgsRendererInMainThread extends PgsRendererImpl {
+
+    public constructor(options: PgsRendererOptions, canvas: HTMLCanvasElement) {
+        super();
+
+        this.pgs = new Pgs();
+        this.renderer = new Renderer(canvas);
+    }
+
+    /**
+     * The PGS loader.
+     * @private
+     */
+    private readonly pgs: Pgs;
+
+    /**
+     * The subtitle renderer, running in the main thread.
+     */
+    private readonly renderer: Renderer;
+
+    protected render(index: number): void {
+        const subtitleData = this.pgs.getSubtitleAtIndex(index);
+        requestAnimationFrame(() => {
+            this.renderer.draw(subtitleData);
+        });
+        this.pgs.cacheSubtitleAtIndex(index + 1);
+    }
+
+    public loadFromUrl(url: string): void {
+        this.pgs.loadFromUrl(url, {
+            onProgress: () => {
+                this.invokeTimestampsUpdate();
+            }
+        }).then(() => {
+            this.invokeTimestampsUpdate();
+        });
+    }
+
+    public loadFromBuffer(buffer: ArrayBuffer): void {
+        this.pgs.loadFromBuffer(buffer).then(() => {
+            this.invokeTimestampsUpdate();
+        });
+    }
+
+    /**
+     * Submits the update timestamps from the pgs loader and invokes events.
+     */
+    private invokeTimestampsUpdate(): void {
+        this.setUpdateTimestamps(this.pgs.updateTimestamps);
+    }
+
+    /**
+     * Disposes the renderer.
+     */
+    public dispose(): void {
+        // Nothing to do
+    }
+}

--- a/src/pgsRendererInWorker.ts
+++ b/src/pgsRendererInWorker.ts
@@ -15,10 +15,6 @@ export abstract class PgsRendererInWorker extends PgsRendererImpl {
         this.worker.onmessage = this.$onWorkerMessage;
     }
 
-    /**
-     * Tells the worker to load the subtitle file from the given url.
-     * @param url The url to the PGS file.
-     */
     public loadFromUrl(url: string): void {
         this.worker.postMessage({
             op: 'loadFromUrl',
@@ -54,14 +50,7 @@ export abstract class PgsRendererInWorker extends PgsRendererImpl {
         switch (e.data.op) {
             // Is called once a subtitle file was loaded.
             case 'updateTimestamps': {
-                // Stores the update timestamps, so we don't need to push the timestamp to the worker on every tick.
-                // Instead, we push the timestamp index if it was changed.
-                this.updateTimestamps = e.data.updateTimestamps;
-
-                // Notify timestamp updates.
-                if (this.onTimestampsUpdated) {
-                    this.onTimestampsUpdated();
-                }
+                this.setUpdateTimestamps(e.data.updateTimestamps);
                 break;
             }
         }

--- a/src/pgsRendererInWorkerWithOffscreenCanvas.ts
+++ b/src/pgsRendererInWorkerWithOffscreenCanvas.ts
@@ -7,23 +7,23 @@ import {PgsRendererInWorker} from "./pgsRendererInWorker";
  */
 export class PgsRendererInWorkerWithOffscreenCanvas extends PgsRendererInWorker {
 
-  public constructor(options: PgsRendererOptions, canvas: HTMLCanvasElement) {
-    super(options);
+    public constructor(options: PgsRendererOptions, canvas: HTMLCanvasElement) {
+        super(options);
 
-    // Initialize the worker with an offscreen-canvas. Rendering will occur in the worker thread.
-    const offscreenCanvas = canvas.transferControlToOffscreen();
-    this.worker.postMessage({
-      op: 'init',
-      canvas: offscreenCanvas,
-    }, [offscreenCanvas]);
-  }
+        // Initialize the worker with an offscreen-canvas. Rendering will occur in the worker thread.
+        const offscreenCanvas = canvas.transferControlToOffscreen();
+        this.worker.postMessage({
+            op: 'init',
+            canvas: offscreenCanvas,
+        }, [offscreenCanvas]);
+    }
 
 
-  protected render(index: number): void {
-    // Tells the worker to render the subtitle at this timestamp index.
-    this.worker.postMessage({
-      op: 'render',
-      index: index
-    });
-  }
+    protected render(index: number): void {
+        // Tells the worker to render the subtitle at this timestamp index.
+        this.worker.postMessage({
+            op: 'render',
+            index: index
+        });
+    }
 }

--- a/src/pgsRendererMode.ts
+++ b/src/pgsRendererMode.ts
@@ -1,0 +1,16 @@
+export enum PgsRendererMode {
+    /**
+     * A worker thread is used to load, build and render the subtitles. This requires OffscreenCanvas support.
+     */
+    worker = 'worker',
+
+    /**
+     * A worker thread is used to load and build the subtitles. They are rendered in the main thread.
+     */
+    workerWithoutOffscreenCanvas = 'workerWithoutOffscreenCanvas',
+
+    /**
+     * The subtitles are loaded, built and rendered in the main thread.
+     */
+    mainThread = 'mainThread',
+}

--- a/src/pgsRendererOptions.ts
+++ b/src/pgsRendererOptions.ts
@@ -1,3 +1,5 @@
+import {PgsRendererMode} from "./pgsRendererMode";
+
 export interface PgsRendererOptions {
     /**
      * The video element to sync the subtitle to.
@@ -25,4 +27,10 @@ export interface PgsRendererOptions {
      * The url to the worker javascript file.
      */
     workerUrl?: string;
+
+    /**
+     * The forced renderer mode.
+     * If not provided, the renderer checks the current browser to detect the best mode for your platform.
+     */
+    mode?: PgsRendererMode;
 }

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -20,7 +20,7 @@ onmessage = (e: MessageEvent) => {
         case 'init': {
             const canvas: OffscreenCanvas = e.data.canvas;
 
-            // The canvas is optional. If
+            // The canvas is optional. If provided, the web-worker can use it to render the subtitles.
             if (canvas) {
                 renderer = new Renderer(canvas);
             }
@@ -70,6 +70,7 @@ onmessage = (e: MessageEvent) => {
             // Returns the data to the main thread.
             postMessage({
                 op: 'subtitleData',
+                index: index,
                 subtitleData: subtitleData
             })
 

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -1,3 +1,8 @@
+// Polyfills
+import "core-js/stable/array/find";
+import "core-js/stable/promise";
+import "whatwg-fetch";
+
 import {Renderer} from "./renderer";
 import {Pgs} from "./pgs";
 

--- a/tests/browserSupport.test.ts
+++ b/tests/browserSupport.test.ts
@@ -1,0 +1,92 @@
+import {BrowserSupport} from "../src/browserSupport";
+import {PgsRendererMode} from "../src/pgsRendererMode";
+
+const devices = [
+    {
+        name: 'WebOS 1.2',
+        userAgent: 'Mozilla/5.0 (Web0S; Linux i686) AppleWebKit/537.41 (KHTML, like Gecko) Large Screen WebAppManager Safari/537.41',
+        worker: true,
+        offscreenCanvas: false,
+        expectedMode: PgsRendererMode.mainThread
+    },
+    {
+        name: 'WebOS 5.0',
+        userAgent: 'Mozilla/5.0 (Web0S; Linux/SmartTV) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.106 Safari/537.36 WebAppManager',
+        worker: true,
+        offscreenCanvas: false,
+        expectedMode: PgsRendererMode.mainThread
+    },
+    {
+        name: 'Chrome 35',
+        userAgent: 'Mozilla/5.0 (Windows NT 5.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/35.0.3319.102 Safari/537.36',
+        worker: true,
+        offscreenCanvas: false,
+        expectedMode: PgsRendererMode.mainThread
+    },
+    {
+        name: 'Chrome 68',
+        userAgent: 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.0.0 Safari/537.36',
+        worker: true,
+        offscreenCanvas: false,
+        expectedMode: PgsRendererMode.workerWithoutOffscreenCanvas
+    },
+    {
+        name: 'Chrome 128',
+        userAgent: 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/128.0.0.0 Safari/537.36',
+        worker: true,
+        offscreenCanvas: true,
+        expectedMode: PgsRendererMode.worker
+    },
+    {
+        name: 'Firefox 24',
+        userAgent: 'Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:24.0) Gecko/20100101 Firefox/24.0',
+        worker: true,
+        offscreenCanvas: false,
+        expectedMode: PgsRendererMode.mainThread
+    },
+    {
+        name: 'Firefox 130',
+        userAgent: 'Mozilla/5.0 (X11; Linux x86_64; rv:130.0) Gecko/20100101 Firefox/130.0',
+        worker: true,
+        offscreenCanvas: true,
+        expectedMode: PgsRendererMode.worker
+    }
+];
+
+describe.each(devices)('on $name', (device) => {
+    beforeEach(() => {
+        Object.defineProperty(global, 'navigator', {
+            configurable: true,
+            value: {
+                userAgent: device.userAgent
+            }
+        });
+
+        Object.defineProperty(global, 'Worker', {
+            configurable: true,
+            value: device.worker ? {} : undefined,
+        });
+
+        Object.defineProperty(global, 'HTMLCanvasElement', {
+            configurable: true,
+            value: {
+                prototype: {
+                    transferControlToOffscreen: device.offscreenCanvas ? () => {} : undefined
+                }
+            }
+        });
+    });
+    afterEach(() => jest.resetAllMocks());
+
+    it(`worker support is ${device.worker}`, () => {
+        expect(BrowserSupport.isWorkerSupported()).toBe(device.worker);
+    });
+
+    it(`offscreen canvas support is ${device.offscreenCanvas}`, () => {
+        expect(BrowserSupport.isOffscreenCanvasSupported()).toBe(device.offscreenCanvas);
+    });
+
+    it(`render mode is ${device.expectedMode}`, () => {
+        expect(BrowserSupport.getRendererModeByPlatform()).toBe(device.expectedMode);
+    });
+});


### PR DESCRIPTION
Added a fallback rendering mode without workers. This loads, builds and renders everything in the main browser thread. This mode is used on legacy devices with missing or broken worker features.

This fixes compatibility issues in WebOS. I was able to test WebOS 1.2 and 5.0. 