### PR TITLE
Fix clear-rect after recent position change

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "libpgs",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "libpgs",
-      "version": "0.8.0",
+      "version": "0.8.1",
       "license": "MIT",
       "devDependencies": {
         "@rollup/plugin-commonjs": "^26.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "libpgs",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "author": "David Schulte",
   "license": "MIT",
   "description": "Renderer for graphical subtitles (PGS) in the browser. ",

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -68,13 +68,15 @@ export class Renderer {
                 compositionObject.horizontalPosition, compositionObject.verticalPosition,
                 compositionObject.croppingHorizontalPosition, compositionObject.croppingVerticalPosition,
                 compositionObject.croppingWidth, compositionObject.croppingHeight);
+
+            dirtyArea?.union(compositionObject.horizontalPosition, compositionObject.verticalPosition,
+                compositionObject.croppingWidth, compositionObject.croppingHeight);
         } else {
             this.context?.putImageData(compositionData.pixelData,
                 compositionObject.horizontalPosition, compositionObject.verticalPosition);
-        }
 
-        // Mark this area as dirty.
-        dirtyArea?.union(compositionData.window.horizontalPosition, compositionData.window.verticalPosition,
-            compositionData.pixelData.width, compositionData.pixelData.height);
+            dirtyArea?.union(compositionObject.horizontalPosition, compositionObject.verticalPosition,
+                compositionData.pixelData.width, compositionData.pixelData.height);
+        }
     }
 }


### PR DESCRIPTION
The fix for #16 created a mismatch between the drawn image and the clearing-rect. This resulted in an issue where drawn subtitles weren't cleared on the next update, like issue #18.

This PR aligned the clearing-rect with the actual draw position of the image by ignoring the PGS window entirely and just use the composition position.